### PR TITLE
New gui2

### DIFF
--- a/omero_search_client/main/views.py
+++ b/omero_search_client/main/views.py
@@ -22,6 +22,14 @@ def get_resources_keys_values():
     #  "well":"{{ url_for("main.get_resourcse_key", resource='well') }}",
     #  "plate":"{{ url_for("main.get_resourcse_key", resource='plate') }}"
     #  }
+
+
+@main.route('/builder',methods=['POST', 'GET'])
+def use_builder_mode():
+    #resources=get_resources("all")
+    return render_template('query_builder.html')#, resources_data=resources,  operator_choices=operator_choices,task_id="None", mode="advanced")#container)
+
+
 @main.route('/advanced',methods=['POST', 'GET'])
 def use_advanced_mode():
     resources=get_resources("all")
@@ -36,7 +44,7 @@ def index ():
 
     '''
     resources=get_resources("searchterms")
-    return render_template('main_page.html', resources_data=resources,  operator_choices=operator_choices,task_id="None", mode="usesearchterms")#container)
+    return render_template('main_page_new_gui.html', resources_data=resources,  operator_choices=operator_choices,task_id="None", mode="usesearchterms")#container)
 
 @main.route('/<resource>/getresourcenames/',methods=['POST', 'GET'])
 def get_resourcse_names(resource):

--- a/omero_search_client/searchengineclientstatic/css/style.css
+++ b/omero_search_client/searchengineclientstatic/css/style.css
@@ -285,3 +285,7 @@ input.editor-checkbox {
   padding-right: 4px;
   visibility: hidden;
 }
+
+#queryJson {
+  width: 90%;
+}

--- a/omero_search_client/searchengineclientstatic/css/style.css
+++ b/omero_search_client/searchengineclientstatic/css/style.css
@@ -288,4 +288,6 @@ input.editor-checkbox {
 
 #queryJson {
   width: 90%;
+  /* temp hack! */
+  height: 500px;
 }

--- a/omero_search_client/searchengineclientstatic/css/style.css
+++ b/omero_search_client/searchengineclientstatic/css/style.css
@@ -260,3 +260,28 @@ input.editor-checkbox {
 }
 
 
+.and_clause {
+  border: solid #aaa 1px;
+  padding: 5px;
+  border-radius: 5px;
+  margin: 5px;
+}
+
+.form-row:first-child .or {
+  visibility: hidden;
+}
+
+.or {
+  padding-top: 33px;
+  text-align: center;
+}
+
+.remove {
+  position: absolute;
+  right: 5px;
+  top: 0;
+  line-height: 1.0;
+  padding-left: 4px;
+  padding-right: 4px;
+  visibility: hidden;
+}

--- a/omero_search_client/searchengineclientstatic/css/style.css
+++ b/omero_search_client/searchengineclientstatic/css/style.css
@@ -271,15 +271,22 @@ input.editor-checkbox {
   visibility: hidden;
 }
 
+.form-row label {
+  display: none;
+}
+.form-row:first-child label {
+  display: inline-block;
+}
+
 .or {
-  padding-top: 33px;
+  padding-top: 10px;
   text-align: center;
 }
 
 .remove {
   position: absolute;
   right: 5px;
-  top: 0;
+  bottom: 5px;
   line-height: 1.0;
   padding-left: 4px;
   padding-right: 4px;
@@ -290,4 +297,8 @@ input.editor-checkbox {
   width: 90%;
   /* temp hack! */
   height: 500px;
+}
+
+.and_clause .form-group {
+  margin-bottom: 2px;
 }

--- a/omero_search_client/searchengineclientstatic/js/resource_handeler_new_gui.js
+++ b/omero_search_client/searchengineclientstatic/js/resource_handeler_new_gui.js
@@ -984,3 +984,53 @@ let file = document.querySelector("#load_file").files[0];
 //wehere  col_i is the column id
 
 
+$(function(){
+
+    function onlyShowOneX() {
+        let $btns = $("button.remove");
+        if ($btns.length == 1) {
+            $btns.css('visibility', 'hidden');
+        } else {
+            $btns.css('visibility', 'visible');
+        }
+    }
+
+    // OR buttons
+    $("#and_condition").on("click", ".addOR", function (event) {
+        let $clause = $(this).parent();
+        let $row = $(".form-row", $clause).last();
+        $row.after($row.clone());
+        onlyShowOneX();
+    });
+
+    // X buttons
+    $("#and_condition").on("click", ".remove", function (event) {
+        let $row = $(this).closest(".form-row");
+        let $clause = $row.parent();
+        $row.remove();
+        // If no rows left, remove clause...
+        if ($(".form-row", $clause).length === 0) {
+            let $and = $clause.prev();
+            if ($and.length == 0) {
+                // in case we're removing the first row
+                $and = $clause.next();
+            }
+            $and.remove();
+            $clause.remove();
+        }
+        onlyShowOneX();
+    });
+
+    // clone empty form row
+    let $andClause = $("#and_condition .and_clause").clone();
+
+    // AND button
+    $("#addAND").on("click", function(){
+        let $form = $(this).parent();
+        let $clause = $(".and_clause", $form).last();
+        $clause.after($andClause.clone());
+        $clause.after("<div>AND</div>");
+        onlyShowOneX();
+    })
+});
+

--- a/omero_search_client/searchengineclientstatic/js/resource_handeler_new_gui.js
+++ b/omero_search_client/searchengineclientstatic/js/resource_handeler_new_gui.js
@@ -1,0 +1,986 @@
+var querystarttime;
+var queryendtime;
+var resource;
+let cancel_check = false;
+var ajaxCall;
+var task_id;
+var set_query_form = false;
+var bookmark;
+var page=0;
+var query;
+var recieved_results=[];
+var size=0;
+var query;
+var pages_data={};
+var ag_grid;
+var recieved_data=0;
+var columnDefs=[];
+var current_values={};
+cached_key_values={};
+var extend_url;
+var names_ids;
+var main_attributes= ["Name (IDR number)"];
+var query_details;
+var raw_elasticsearch_query;
+var no_cloned =0;
+var original_external_int_div = document.getElementById('template'); //Div to Clone
+var or_template = document.getElementById('ortemplate');
+var or_parent=document.getElementById('conanewor');
+
+
+//save query json string to the local user storage, so he cal load it again
+function save_query()
+ {
+    query=get_current_query(false);
+    if (query==false)
+        return;
+    else
+    {
+        $("#confirm_message").modal("show");
+            document.getElementById("queryfilename").focus();
+
+        }
+}
+
+//Save query to user local storage
+function download_query()
+{
+filename=document.getElementById("queryfilename").value;
+query=JSON.stringify(get_current_query(false), null, 4);
+if (filename) {
+    filename=filename+'.txt'
+    var file_container = document.createElement('a');
+    file_container.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(query));
+    file_container.setAttribute('download', filename);
+
+    if (document.createEvent) {
+        var event = document.createEvent('MouseEvents');
+        event.initEvent('click', true, true);
+        file_container.dispatchEvent(event);
+    }
+    else {
+        file_container.click();
+    }
+    $("#confirm_message").modal("hide");
+    document.getElementById("queryfilename").value="";
+}
+}
+
+//
+function new_query(){
+    query=get_current_query(false);
+    if (query==false)
+        return;
+    if (confirm("All the conditions will be discarded, process?") == true) {
+        //remove_all_conditiona("or");
+        //remove_all_conditiona("and");
+        location.reload();
+        return false;
+    }
+}
+function load_query(){
+    $('#load_file').click();
+}
+
+//Load query from file which is located in the user machine
+function load_query_from_file(file)
+{
+    //remove anycondition if any
+    remove_all_conditiona("or");
+    remove_all_conditiona("and");
+    let reader = new FileReader();
+
+    reader.addEventListener('load', function(e) {
+    let text = e.target.result;
+    data_=JSON.parse(text);
+    data=data_["query_details"]
+    var orFilter = data["or_filters"];
+    var andFilter = data["and_filters"];
+    case_sensitive= data["case_sensitive"];
+    resource = data_["resource"]
+    for (i in orFilter)
+            {
+            addConditionRow(orFilter[i]["name"],orFilter[i]["value"], orFilter[i]["operator"], orFilter[i]["resource"], 'or');
+            }
+    for (i in andFilter)
+        {
+         addConditionRow(andFilter[i]["name"],andFilter[i]["value"], andFilter[i]["operator"], andFilter[i]["resource"], 'and');
+
+            }
+
+            document.getElementById('case_sensitive').checked=case_sensitive;
+        });
+		reader.readAsText(file);
+		document.querySelector("#load_file")="";
+}
+function changeMainAttributesFunction (){
+    var checkbox = document.getElementById("add_main_attibutes");
+    mainvalueFields=document.getElementById("mainvalue");
+    maincondtion=document.getElementById("maincondition");
+    mainkeyFields=document.getElementById("mainkey");
+     if (checkbox.checked)
+     {
+        mainvalueFields.style.display = "block";
+        maincondtion.style.display = "block";
+        mainkeyFields.style.display = "block";
+     }
+     else
+     {
+        mainvalueFields.style.display = "none";
+        maincondtion.style.display = "none";
+        mainkeyFields.style.display = "none";
+     }
+}
+
+function cancell_ajaxcall() {
+    ajaxCall.onreadystatechange = null;
+    ajaxCall.abort();
+    console.log("Canceled");
+    ajaxCall = null;
+    return;
+    }
+
+//display message to the user
+function displayMessage(header, body, btn_text) {
+    messageHeader.innerText = header;
+    messageBody.innerText = body;
+    if (typeof(btn_text) !== "undefined" && btn_text !== null)
+        moelButton.innerText = btn_text;
+    $("#displaymessagemodal").modal("show");
+    $("#moelButton").hide();
+}
+
+function cancelFunction() {
+    cancel_check = true;
+    cancell_ajaxcall();
+    $("#moelButton").hide();
+}
+
+function urlFormatter
+(row, cell, value, columnDef, dataContext) {
+    return "<a href=" + value + " target='_blank'>" + value + "</a>";
+}
+
+function valueFormatter(row, cell, value, columnDef, dataContext) {
+try {
+       return value.toString();
+
+}
+catch(err) {
+    alert ("Error "+err+", for value: "+value);
+}
+
+}
+
+function loadMoreResultsFunction()
+{
+    submitQuery();
+}
+
+function wait(ms){
+   var start = new Date().getTime();
+   var end = start;
+   while(end < start + ms) {
+     end = new Date().getTime();
+  }
+}
+
+function loadRemainingResultsFunction() {
+while (recieved_data<size) {
+  wait (5000);
+  submitQuery();
+}
+}
+
+function set_global_variables(data)
+    {
+    bookmark=data["bookmark"];
+    raw_elasticsearch_query=data["raw_elasticsearch_query"];
+    page=page+1;
+    pages_data[page]=data;
+    recieved_results=recieved_results.concat(data["values"]);
+    size=data["size"];
+    query_details=data["query_details"];
+    recieved_data=recieved_data+data["values"].length;
+    if (recieved_data>=size){
+    var resultsbutton = document.getElementById('loadMoreResults');
+    resultsbutton.disabled = true;
+    }
+}
+function sizeToFit() {
+  ag_grid.gridOptions.api.sizeColumnsToFit();
+}
+
+function resetResultsTabelFilters()
+{
+    ag_grid.gridOptions.api.setFilterModel(null);
+    ag_grid.gridOptions.api.onFilterChanged();
+}
+
+
+function getBoolean(id) {
+  //var field = document.querySelector('#' + id);
+  return true;
+}
+
+function getParams() {
+  return {
+    allColumns: getBoolean('allColumns'),
+    //columnSeparator: '\t'
+  };
+}
+
+function exportToCSV() {
+  ag_grid.gridOptions.api.exportDataAsCsv(getParams());
+}
+
+function autoSizeAll(skipHeader) {
+  var allColumnIds = [];
+  gridOptions.columnApi.getAllColumns().forEach(function (column) {
+    allColumnIds.push(column.colId);
+  });
+  gridOptions.columnApi.autoSizeColumns(allColumnIds, skipHeader);
+    }
+
+function url_render(param){
+    if (resource =="screen")
+        return '<a href='+extend_url +' target="_blank" >'+param.value+'</a>'
+    else
+        return '<a href='+extend_url +param.value+' target="_blank" >'+param.value+'</a>'
+    }
+
+function onGridSizeChanged(params) {
+        // get the current grids width
+        var gridWidth = document.getElementById('grid-wrapper').offsetWidth;
+        // keep track of which columns to hide/show
+        var columnsToShow = [];
+        var columnsToHide = [];
+        // iterate over all columns (visible or not) and work out
+        // now many columns can fit (based on their minWidth)
+        var totalColsWidth = 0;
+        var allColumns = params.columnApi.getAllColumns();
+        for (var i = 0; i < allColumns.length; i++) {
+        let column = allColumns[i];
+        totalColsWidth += column.getMinWidth();
+        if (totalColsWidth > gridWidth) {
+                columnsToHide.push(column.colId);
+            } else {
+                columnsToShow.push(column.colId);
+            }
+        }
+
+        // show/hide columns based on current grid width
+        params.columnApi.setColumnsVisible(columnsToShow, true);
+        params.columnApi.setColumnsVisible(columnsToHide, false);
+
+        // fill out any available space to ensure there are no gaps
+        params.api.sizeColumnsToFit();
+}
+
+function displayResults(data, new_data=true) {
+   if (new_data)
+   set_global_variables(data);
+
+columnDefs =data["columns_def"]
+extend_url=data["extend_url"];
+names_ids=data["names_ids"];
+for (i in data["columns_def"])
+    {
+    if(data["columns_def"][i]["field"]==="Id")// && resource==="image")
+         data["columns_def"][i]['cellRenderer']=url_render;
+     }
+
+results = data["values"];
+
+var gridOptions = {
+  defaultColDef: {
+    resizable: true,
+  "filter": true,
+  "animateRows":true,
+  },
+ enableCellTextSelection: true,
+  columnDefs: columnDefs,
+  rowData: null,
+
+};
+
+
+ // lookup the container we want the Grid to use
+  const eGridDiv = document.querySelector('#myGrid_2');
+
+  // create the grid passing in the div to use together with the columns & data we want to use
+  if (page==1)
+  ag_grid=new agGrid.Grid(eGridDiv, gridOptions);
+  ag_grid.gridOptions.api.setRowData(recieved_results);
+  var notice = data["notice"];
+
+  server_query_time = data["server_query_time"];
+  //results = data["values"];
+  let no_image = results.length;
+  if (set_query_form == true) {
+        var filters = data["filters"];
+        var orFilter = filters["or_filters"];
+        var andFilter = filters["and_filters"];
+        var notFilter = filters["not_filters"];
+        resource = data["resource"]
+        for (i in orFilter)
+            for (const [key, value] of Object.entries(orFilter[i])) {
+                addConditionRow(key, value, "or");
+            }
+        for (i in andFilter)
+            for (const [key, value] of Object.entries(andFilter[i])) {
+
+                addConditionRow(key, value, "and");
+            }
+        for (i in notFilter)
+            for (const [key, value] of Object.entries(notFilter[i])) {
+                addConditionRow(key, value, "not");
+            }
+        message = "No of "+data["resource"]+" , "+ recieved_data +"/"+size+", Search engine query time: " + server_query_time + " seconds.";
+    } else {
+        var querytime = (queryendtime - querystarttime) / 1000;
+        if (no_image!=size)
+         {
+            message = "No of "+data["resource"]+ ", "+ recieved_data +"/"+size + ", Search engine query time: " + server_query_time + " seconds.";
+             document.getElementById('loadMoreResults').style.display = "block";
+            }
+        else
+        {
+            message = "No of "+data["resource"] +", "+ recieved_data+ ", Search engine query time: " + server_query_time + " seconds.";
+             document.getElementById('loadMoreResults').style.display = "none";
+            }
+    }
+
+    var resultsDiv = document.getElementById('results');
+    var conditions_con = document.getElementById('conditions');
+    var resources_con = document.getElementById('resources');
+    var help = document.getElementById('help');
+    var submit_button = document.getElementById('submit_');
+    var load_query_button=document.getElementById('load_query');
+    conditions_con.disabled = true;
+    document.getElementById('exportResults').style.display = "block";
+    document.getElementById('reset_results_table_filter').style.display = "block";
+    var query_cr = document.getElementById('conditions');
+    resultsDiv.style.display = "block";
+    $('#no_images').text(message);
+    var grid;
+    var columns = data["columns"];
+     for (var i = 0; i < columns.length; i++) {
+        columns[i].formatter=valueFormatter;
+    }
+
+    var options = {
+        enableCellNavigation: true,
+        enableColumnReorder: false,
+        multiColumnSort: true,
+        forceFitColumns: true
+    };
+    $('#displaymessagemodal').modal('hide');
+    var nodes = document.getElementById("conditions").getElementsByTagName('*');
+
+    for (var i = 0; i < nodes.length; i++) {
+        nodes[i].disabled = true;
+    }
+
+    window.location.hash = '#results';
+    document.getElementById('load_results_buttons').style.display = "block";
+    if (new_data)
+    {
+     return;
+    var tr = document.getElementById('loads_results_table').tHead.children[0],
+    th = document.createElement('th');
+    tr.appendChild(th);
+    var pagebutton = document.createElement("BUTTON");
+    pagebutton.innerHTML = page;
+    th.appendChild(pagebutton);
+    th.appendChild(pagebutton);
+    pagebutton.addEventListener("click", function() {
+        alert(pagebutton.innerText);
+        displayResults(data, false);
+    });
+    }
+}
+
+function get_query_data(group_table_) {
+    query_items = [];
+    let group_table = document.getElementById(group_table_);
+    for (var r = 1; r < group_table.rows.length; r++) {
+        query_dict = {}
+        query_items[r - 1] = query_dict;
+        name_ = group_table.rows[r].cells[0].innerHTML;
+        operator_ = group_table.rows[r].cells[1].innerHTML;
+        value_ = group_table.rows[r].cells[2].innerHTML;
+        resource_=group_table.rows[r].cells[3].innerHTML;
+        query_dict["name"]=name_
+        query_dict["value"]=value_
+        query_dict["operator"]=operator_
+        query_dict["resource"]=resource_
+    }
+    return query_items;
+}
+
+    var filterParams = {
+    suppressAndOrCondition: true,
+    comparator: function (filterLocalDateAtMidnight, cellValue) {
+    var dateAsString = cellValue;
+    if (dateAsString == null)
+        return -1;
+    var dateParts = dateAsString.split('/');
+    var cellDate = new Date(
+    Number(dateParts[2]),
+    Number(dateParts[1]) - 1,
+    Number(dateParts[0])
+    );
+
+    if (filterLocalDateAtMidnight.getTime() === cellDate.getTime()) {
+      return 0;
+    }
+
+    if (cellDate < filterLocalDateAtMidnight) {
+      return -1;
+    }
+
+    if (cellDate > filterLocalDateAtMidnight) {
+      return 1;
+    }
+  },
+  browserDatePicker: true,
+};
+
+function get_all_records_query()
+    {
+    query_details = {}
+    all_query = {
+            "match_all" : {}
+             }
+    resource = document.getElementById('resourcseFields').value;
+    var query_ = {
+                "resource": resource,
+                "query_details": query_details,
+                "raw_elasticsearch_query": all_query
+            };
+    query_["mode"]=mode;
+    return query_;
+         }
+
+
+function get_returned_query_from_server()
+        {
+        resource = "image";//document.getElementById('resourcseFields').value;
+        var query_ = {
+            "resource": resource,
+            "query_details": query_details,
+            "raw_elasticsearch_query": raw_elasticsearch_query
+        };
+          query_["bookmark"]=bookmark;
+          query_["columns_def"]=columnDefs;
+          return query_;
+    }
+
+function get_current_query(include_addition_information,displaymessage=true)
+    {
+    and_conditions=[];
+    or_conditions=[];
+    //get and condition1
+    queryandnodes=document.getElementById("conanew").childNodes;
+    for ( i in queryandnodes)
+        {
+             if (queryandnodes[i].nodeName=="DIV"  && queryandnodes[i].id.includes("template"))
+            {
+            ext=queryandnodes[i].id.split("_");
+            if (ext.length==1)
+                    ext='';
+            else
+                ext="_"+ext[1];
+            query_dict={};
+            and_conditions.push(query_dict);
+            attribute=document.getElementById("keyFields"+ext).value;
+            condition=document.getElementById("condtion"+ext).value;
+            value=document.getElementById("valueFields"+ext).value;
+            query_dict["name"]=attribute;
+            query_dict["value"]=value;
+            query_dict["operator"]=condition;
+            query_dict["resource"]=get_resource(attribute);
+            }
+            }
+       queryornodes=or_parent.parentNode.childNodes;
+       for ( i in queryornodes)
+            {
+        if (queryornodes[i].nodeName=="DIV"  && queryornodes[i].id.includes("conanewor"))
+            {
+                panel_cond=[];
+        for (j in queryornodes[i].childNodes)
+            {
+        if (queryornodes[i].childNodes[j].nodeName=="DIV"  && queryornodes[i].childNodes[j].id.includes("template") && !queryornodes[i].childNodes[j].id.includes("ortemplate"))
+            {
+            or_conditions.push(panel_cond);
+            console.log("or condition is found "+queryornodes[i].childNodes[j].id);
+            ext_=queryornodes[i].childNodes[j].id.split("_");
+        if (ext_.length==1)
+            ext_='';
+        else
+            ext_="_"+ext_[1];
+       query_dict={};
+       panel_cond.push(query_dict);
+       attribute=document.getElementById("keyFields"+ext_).value;
+       condition=document.getElementById("condtion"+ext_).value;
+       value=document.getElementById("valueFields"+ext_).value;
+       query_dict["name"]=attribute;
+       query_dict["value"]=value;
+       query_dict["operator"]=condition;
+       query_dict["resource"]=get_resource(attribute);
+       }
+                }
+                        }
+                                }
+    query_details = {}
+     var query = {
+        "resource": "image",
+        "query_details": query_details
+    };
+
+    query_details["and_filters"] = and_conditions;
+    query_details["or_filters"] = or_conditions;
+    query_details["case_sensitive"]=document.getElementById('case_sensitive').checked;
+    query["mode"]=mode;
+    return query;
+
+}
+
+function submitQuery() {
+
+   if (query_details === undefined || size==0)
+     {
+        query=get_current_query(true);
+            if (query==false)
+                return;
+        }
+   else
+        query=get_returned_query_from_server()
+
+   send_the_request(query);
+
+}
+
+function send_the_request(query)
+{
+$.ajax({
+        type: "POST",
+        url: submitqueryurl,
+        contentType: "application/json;charset=UTF-8",
+        dataType: 'json',
+        data: JSON.stringify(query),
+        success: function(data) {
+            if (data["Error"] != "none") {
+                alert(data["Error"]);
+                return;
+            }
+            displayResults(data);
+        },
+        error: function(XMLHttpRequest, textStatus, errorThrown) {
+            alert("Status: " + textStatus);
+            alert("Error: " + errorThrown);
+        }
+    });
+}
+
+function addAndConditionFunction()
+{
+    AddConditionFunction("and");
+}
+
+function addOrConditionFunction(group)
+{
+ if (group=="None" || Number.isInteger(group))
+    AddConditionFunction("or", group);
+else
+    AddConditionFunction(group);
+}
+
+function AddConditionFunction(group, parent=0) {
+        no_cloned+=1;
+        var clone = original_external_int_div.cloneNode(true); // "deep" clone
+        clone.id = clone.id+"_"+ no_cloned; // there can only be one element with an ID
+        var delete_button = document.createElement("BUTTON");
+        delete_button.innerHTML = "x";
+        delete_button.style.color="red";
+        var br_sep=document.createElement("br");
+        delete_button.style.cssFloat = "right";
+        delete_button.onclick= function()
+        {
+                pp_node=clone.parentNode;
+                clone.remove();
+                br_sep.remove();
+                if(pp_node.childNodes.length==3 && (group=="or" || group =="+ Or"))
+                    {
+                    idp=pp_node.id.split("_");
+                    pp_node.remove();
+                    document.getElementById("inbutton_"+idp[1]).remove();
+                    }
+              }
+        clone.insertBefore(delete_button, clone.firstChild);
+
+        $(clone).find("*[id]").each(function(){
+           $(this).val('');
+           var tID = $(this).attr("id");
+           var idArray = tID.split("_");
+           var idArrayLength = idArray.length;
+           var newId = tID+"_"+no_cloned;
+           $(this).attr('id', newId);
+        });
+
+        clone.style.border = "thin dotted green";
+
+        if ( group=="and")
+        {
+        original_external_int_div.parentNode.append(br_sep);
+        original_external_int_div.parentNode.append(clone);
+        }
+        else if  (group=="+ Or")
+        {
+            par_clone_clone=or_parent.cloneNode(true);
+            par_clone_clone.id = or_parent.id+"_"+ no_cloned;
+            var bt_sep_2=document.createElement("BUTTON");
+            bt_sep_2.id="inbutton_"+no_cloned;
+            bt_sep_2.innerHTML="and";
+            or_parent.parentNode.append(bt_sep_2);
+            or_parent.parentNode.append(par_clone_clone);
+            par_clone_clone.style.border = "thick dotted green";
+            par_clone_clone.append(br_sep);
+            par_clone_clone.append(clone);
+            parent_node=par_clone_clone;
+        }
+        else if (parent !=0)
+        {
+             parent_node=parent;//document.getElementById('cona_new_or_'+parent);
+             parent_node.append(br_sep);
+             parent_node.append(clone);
+        }
+
+          if (group=="or" || group =="+ Or")
+        {
+            document.getElementById("insidebutton"+"_"+ no_cloned).value="or";
+            document.getElementById("insidebutton"+"_"+ no_cloned).innerHTML="or";
+            $("#insidebutton_"+no_cloned).unbind();
+            document.getElementById("insidebutton"+"_"+ no_cloned).onclick= function()
+              {
+               AddConditionFunction("or", this.parentNode.parentNode);
+              }
+        }
+                set_query_fields("_"+no_cloned);
+}
+
+function set_query_fields(id)
+    {
+            let selected_resource_ = document.getElementById('resourcseFields'+id);
+            let keys_options_ = document.getElementById('keyFields'+id);
+            let keyFields_= document.getElementById('keyFields'+id);
+            let valueFields_= document.getElementById('valueFields'+id);
+            //valueFields
+            $("#resourcseFields"+id).unbind();
+            $("#keyFields"+id).unbind();
+            $("#keyFields"+id).unbind();
+            $("#valueFields"+id).unbind();
+
+            keys_options_.onchange = function() {
+                key_value = keys_options_.value;
+                set_key_values(key_value,id);
+            }
+
+    valueFields_.addEventListener("onfocus", function() {
+    setAutoCompleteValues();
+        });
+      optionHtml = ''
+      let condtion__ = document.getElementById('condtion'+id)
+       optionOpHtml = ''
+       for (i in operator_choices)
+           {
+             optionOpHtml += '<option value ="' + operator_choices[i][0] + '">' + operator_choices[i][1]+ '</option>'
+           }
+       condtion__.innerHTML = optionOpHtml;
+       var resources_con = document.getElementById('resources');
+       resources_con.style.display = "block";
+       set_resources("image",id);
+}
+
+function AddConditionFunction_(group) {
+    let value_fields = document.getElementById('valueFields');
+    let condtion = document.getElementById('condtion').value;
+    let key = keys_options.value;
+    let value = value_fields.value;
+    let resource = resourcseFields.value;
+    if (!value || value.length === 0)
+    {
+        alert("Please select a value");
+        return;
+    }
+
+    if (!key || key.length === 0) {
+        alert("Please select an attribute");
+        return;
+    }
+    addConditionRow(key, value, condtion, resource, group);
+}
+
+function remove_all_conditiona(group)
+{
+    let tableRef = document.getElementById(group + "_group");
+    var rowCount = tableRef.rows.length;
+    for (var i = 1; i < rowCount; i++)
+        {
+            tableRef.deleteRow(1);
+        }
+}
+
+function addConditionRow(key, value, condtion, resource, group) {
+    let tableRef = document.getElementById(group + "_group");
+    let newRow = tableRef.insertRow(-1);
+    // Insert cells in the row
+    let keyCell = newRow.insertCell(0);
+    let operatorCell = newRow.insertCell(1);
+    let valueCell = newRow.insertCell(2);
+    let resourceCell = newRow.insertCell(3);
+    let removeCell = newRow.insertCell(4);
+
+    // Append a text node to the cells
+    let keyText = document.createTextNode(key);
+    keyCell.appendChild(keyText);
+
+    let operatorText = document.createTextNode(condtion);
+    operatorCell.appendChild(operatorText)
+
+    let valueText = document.createTextNode(value);
+    valueCell.appendChild(valueText);
+
+    let resourceText = document.createTextNode(resource);
+    resourceCell.appendChild(resourceText);
+
+    var removebutton = document.createElement("BUTTON");
+    removebutton.innerHTML = "X Remove";
+    removebutton.setAttribute("class", "btn btn-danger btn-sm");
+    removeCell.appendChild(removebutton);
+
+    removebutton.addEventListener("click", function() {
+        var row = removebutton.parentNode.parentNode;
+        row.parentNode.removeChild(row);
+    });
+}
+
+/*
+set autocpmlete values for key using a function to filter the available values
+It solves the issue of having many available values (sometimes tens of thousnads),
+it was freezing the interface */
+function setAutoCompleteValues(){
+ document.activeElement.addEventListener("keyup", function() {
+ console.log("eees");
+        $("#"+document.activeElement.id) .autocomplete({
+                   source:  setFieldValues(),
+                   minLength:0
+        });
+    });
+}
+
+//As main attributes supports equals andnot equals only
+//This function restrict the use to these two operators
+function set_operator_options(key_value)
+{
+condtion = document.getElementById("condtion");
+condtion.value=condtion.options[0].text;
+for (i =0; i< condtion.length; i++  )
+{
+
+if (main_attributes.includes(key_value))
+    {
+         if (condtion.options[i].text!= "equals" && condtion.options[i].text!="not equals")
+            condtion.options[i].style.display = "none";
+
+      }
+ else
+    {
+        condtion.options[i].style.display = "block";
+    }
+
+    }
+}
+function get_resource(attribute)
+{
+ for (resource in resources_data) {
+                if (resources_data[resource].includes(attribute))
+                {
+                return resource;
+                }
+            }
+}
+
+function set_key_values(key_value, id) {
+
+  $( "#value_field"+id ).val('');
+  if (id===undefined || id ==='')
+        id_="-1";
+   else
+         id_=id;
+
+
+resource=get_resource(key_value);
+
+    set_operator_options(key_value);
+if (cached_key_values[key_value]===undefined)
+{
+    let selected_resource_ = document.getElementById('resourcseFields'+id);
+    //resource = selected_resource_.value;
+    url=getresourcesvalesforkey+ "/?key=" + encodeURIComponent(key_value)+"&&resource="+ encodeURIComponent(resource);
+    fetch(url).then(function(response) {
+      {
+        response.json().then(function(data) {
+            data.sort();
+            current_values[id_]=data;
+            cached_key_values[key_value]=data;
+
+                });
+            }
+    });
+    }
+    else
+    {
+    console.log("Hiiii: ", key_value+","+id);
+        current_values[id_]=cached_key_values[key_value];
+    }
+
+}
+
+ function setFieldValues(){
+    let value_fields = document.activeElement;//document.getElementById('valueFields'+id);
+    selected_resource_ids=value_fields.id.split("_");
+    if (selected_resource_ids.length==1)
+         vid=["-1"]
+       else
+          vid="_"+selected_resource_ids[1];
+   current_value=current_values[vid]
+
+    let val=value_fields.value;
+    //for performance, when the length of the current values length is bigger than 1000, when the value is one letter, it will only return all the items which start with this letter
+    //otherwise, it will return all the items which contains the value (even ther are  at the middle or at the end of the items)
+    if (current_values.length>1000)
+    {
+    console.log("1: val: "+val);
+
+      if (!val || val.length <2  )
+        return [];
+    else
+        if (val.length ===2)
+            return  current_value.filter(x => x.toLowerCase().startsWith(val.toLowerCase()))
+    else
+         return current_value.filter(x => x.toLowerCase().includes(val.toLowerCase()))
+   }
+    else
+    {
+         return current_value.filter(x => x.toLowerCase().includes(val.toLowerCase()))
+        }
+
+}
+
+function set_resources(resource, id) {
+    let __keys_options=document.getElementById('keyFields'+id);
+    optionHtml = '';
+
+    for (const [key, value] of Object.entries(resources_data)) {
+       // if (key == resource) {
+            if (value==null)
+              {
+              __keys_options.innerHTML = optionHtml;
+            break;
+              }
+             //if (key=="image")
+             //      //#value.unshift("Project name");
+             //      value.push("Project name");
+             value.sort();
+            for (i in value) {
+                optionHtml += '<option value ="' + value[i] + '">' + value[i] + '</option>'
+            }
+
+
+          //  break;
+       // }
+    }
+           __keys_options.innerHTML = optionHtml;
+
+    key_value = __keys_options.value;
+    set_key_values(key_value, id);
+}
+/*
+let _selected_resource = document.getElementById('resourcseFields');
+let _keys_options = document.getElementById('keyFields');
+let _keyFields= document.getElementById('keyFields');
+
+
+_selected_resource.onchange = function() {
+    selected_resource_ids=_selected_resource.id.split("_");
+    if (selected_resource_ids.length==1)
+         set_resources(resource, '');
+       else
+          set_resources(resource, "_"+selected_resource_ids[1]);
+
+}
+
+_keys_options.onchange = function() {
+    key_value = _keys_options.value;
+    keys_options_ids=_keys_options.id.split("_");
+    if (keys_options_ids.length==1)
+        set_key_values(key_value, '');
+
+       else
+
+        set_key_values(key_value, '_'+keys_options_ids[1]);
+}
+*/
+$(document).ready(function() {
+    let _selected_resource = document.getElementById('resourcseFields');
+    let _keys_options = document.getElementById('keyFields');
+    let _keyFields= document.getElementById('keyFields');
+
+    if (query_id != "None") {
+        set_query_form = true;
+        task_id = query_id;
+        header = "Retrieve results";
+        body = "Please wait while retrieving the results for \n\rQuery no: " + task_id + ", this may take some time";
+        displayMessage(header, body);
+        setTimeout(function() {
+            get_results();
+        }, 600);
+
+    } else {
+    optionHtml = ''
+    for (key in resources_data) {
+                optionHtml += '<option value ="' + key + '">' + key+ '</option>'
+            }
+
+       //resourcseFields.innerHTML = optionHtml;
+       optionOpHtml = ''
+       for (i in operator_choices)
+       {
+         optionOpHtml += '<option value ="' + operator_choices[i][0] + '">' + operator_choices[i][1]+ '</option>'
+       }
+       condtion.innerHTML = optionOpHtml;
+        var resources_con = document.getElementById('resources');
+        resources_con.style.display = "block";
+        //resource = _selected_resource.value = 'image';
+
+        set_query_fields("");
+
+        //set_resources('image','');
+    }
+});
+//Used to load query from local storage
+document.getElementById('load_file').onchange = function () {
+let file = document.querySelector("#load_file").files[0];
+  load_query_from_file(file);
+}
+
+//this.agGrid.columnApi.setColumnsVisible(["COL_1", "COL_2"], false);
+//this.agGrid.columnApi.setColumnsVisible(["COL_1", "COL_2"], true);
+//const group = this.columnApi.getColumnGroup("MY_GROUP");
+//group.children.forEach(child => this.columnApi.setColumnsVisible(child, false));
+//
+//wehere  col_i is the column id
+
+

--- a/omero_search_client/searchengineclientstatic/js/resource_handeler_new_gui.js
+++ b/omero_search_client/searchengineclientstatic/js/resource_handeler_new_gui.js
@@ -78,59 +78,57 @@ function new_query(){
         return false;
     }
 }
-function load_query(){
-    $('#load_file').click();
-}
+
 
 //Load query from file which is located in the user machine
-function load_query_from_file(file)
-{
-    //remove anycondition if any
-    remove_all_conditiona("or");
-    remove_all_conditiona("and");
-    let reader = new FileReader();
+// function load_query_from_file(file)
+// {
+//     //remove anycondition if any
+//     remove_all_conditiona("or");
+//     remove_all_conditiona("and");
+//     let reader = new FileReader();
 
-    reader.addEventListener('load', function(e) {
-    let text = e.target.result;
-    data_=JSON.parse(text);
-    data=data_["query_details"]
-    var orFilter = data["or_filters"];
-    var andFilter = data["and_filters"];
-    case_sensitive= data["case_sensitive"];
-    resource = data_["resource"]
-    for (i in orFilter)
-            {
-            addConditionRow(orFilter[i]["name"],orFilter[i]["value"], orFilter[i]["operator"], orFilter[i]["resource"], 'or');
-            }
-    for (i in andFilter)
-        {
-         addConditionRow(andFilter[i]["name"],andFilter[i]["value"], andFilter[i]["operator"], andFilter[i]["resource"], 'and');
+//     reader.addEventListener('load', function(e) {
+//     let text = e.target.result;
+//     data_=JSON.parse(text);
+//     data=data_["query_details"]
+//     var orFilter = data["or_filters"];
+//     var andFilter = data["and_filters"];
+//     case_sensitive= data["case_sensitive"];
+//     resource = data_["resource"]
+//     for (i in orFilter)
+//             {
+//             addConditionRow(orFilter[i]["name"],orFilter[i]["value"], orFilter[i]["operator"], orFilter[i]["resource"], 'or');
+//             }
+//     for (i in andFilter)
+//         {
+//          addConditionRow(andFilter[i]["name"],andFilter[i]["value"], andFilter[i]["operator"], andFilter[i]["resource"], 'and');
 
-            }
+//             }
 
-            document.getElementById('case_sensitive').checked=case_sensitive;
-        });
-		reader.readAsText(file);
-		document.querySelector("#load_file")="";
-}
-function changeMainAttributesFunction (){
-    var checkbox = document.getElementById("add_main_attibutes");
-    mainvalueFields=document.getElementById("mainvalue");
-    maincondtion=document.getElementById("maincondition");
-    mainkeyFields=document.getElementById("mainkey");
-     if (checkbox.checked)
-     {
-        mainvalueFields.style.display = "block";
-        maincondtion.style.display = "block";
-        mainkeyFields.style.display = "block";
-     }
-     else
-     {
-        mainvalueFields.style.display = "none";
-        maincondtion.style.display = "none";
-        mainkeyFields.style.display = "none";
-     }
-}
+//             document.getElementById('case_sensitive').checked=case_sensitive;
+//         });
+// 		reader.readAsText(file);
+// 		document.querySelector("#load_file")="";
+// }
+// function changeMainAttributesFunction (){
+//     var checkbox = document.getElementById("add_main_attibutes");
+//     mainvalueFields=document.getElementById("mainvalue");
+//     maincondtion=document.getElementById("maincondition");
+//     mainkeyFields=document.getElementById("mainkey");
+//      if (checkbox.checked)
+//      {
+//         mainvalueFields.style.display = "block";
+//         maincondtion.style.display = "block";
+//         mainkeyFields.style.display = "block";
+//      }
+//      else
+//      {
+//         mainvalueFields.style.display = "none";
+//         maincondtion.style.display = "none";
+//         mainkeyFields.style.display = "none";
+//      }
+// }
 
 function cancell_ajaxcall() {
     ajaxCall.onreadystatechange = null;
@@ -356,7 +354,6 @@ var gridOptions = {
     var resources_con = document.getElementById('resources');
     var help = document.getElementById('help');
     var submit_button = document.getElementById('submit_');
-    var load_query_button=document.getElementById('load_query');
     conditions_con.disabled = true;
     document.getElementById('exportResults').style.display = "block";
     document.getElementById('reset_results_table_filter').style.display = "block";
@@ -483,7 +480,7 @@ function get_current_query(include_addition_information,displaymessage=true)
     or_conditions=[];
     //get and condition1
 
-    queryandnodes = document.querySelectorAll('#and_condition .and_clause');
+    queryandnodes = document.querySelectorAll('#search_form .and_clause');
     console.log(queryandnodes.length);
     for (let i=0; i<queryandnodes.length; i++) {
 
@@ -945,10 +942,10 @@ $(document).ready(function() {
     }
 });
 //Used to load query from local storage
-document.getElementById('load_file').onchange = function () {
-let file = document.querySelector("#load_file").files[0];
-  load_query_from_file(file);
-}
+// document.getElementById('load_file').onchange = function () {
+// let file = document.querySelector("#load_file").files[0];
+//   load_query_from_file(file);
+// }
 
 //this.agGrid.columnApi.setColumnsVisible(["COL_1", "COL_2"], false);
 //this.agGrid.columnApi.setColumnsVisible(["COL_1", "COL_2"], true);
@@ -958,7 +955,13 @@ let file = document.querySelector("#load_file").files[0];
 //wehere  col_i is the column id
 
 
+let $andClause;
+
 $(function(){
+
+    // clone empty form row before any changes
+    // used for building form
+    $andClause = $("#search_form .and_clause").clone();
 
     // Hide the X button if there's only 1 in the form
     function hideRemoveIfOnlyOneLeft() {
@@ -979,15 +982,15 @@ $(function(){
     }
 
     // OR buttons
-    $("#and_condition").on("click", ".addOR", function (event) {
+    $("#search_form").on("click", ".addOR", function (event) {
+        event.preventDefault();
         let $clause = $(this).parent();
-        let $row = $(".form-row", $clause).last();
-        $row.after($row.clone());
+        addOr($clause);
         updateForm();
     });
 
     // X buttons
-    $("#and_condition").on("click", ".remove", function (event) {
+    $("#search_form").on("click", ".remove", function (event) {
         let $row = $(this).closest(".form-row");
         let $clause = $row.parent();
         $row.remove();
@@ -1004,23 +1007,96 @@ $(function(){
         updateForm();
     });
 
-    // clone empty form row before any changes
-    let $andClause = $("#and_condition .and_clause").clone();
-
     // AND button
     $("#addAND").on("click", function(){
-        let $form = $(this).parent();
-        let $clause = $(".and_clause", $form).last();
-        $clause.after($andClause.clone());
-        $clause.after("<div>AND</div>");
+        addAnd();
         updateForm();
     });
 
     // handle any input/select changes to update textarea
-    $("#and_condition").on("change", "select", updateForm);
-    $("#and_condition").on("keyup", "input", updateForm);
+    $("#search_form").on("change", "select", updateForm);
+    $("#search_form").on("keyup", "input", updateForm);
 
     // initial update of JSON textarea
     updateForm()
 });
+
+function addAnd(attribute, operator, value) {
+    let $form = $("#search_form");
+    if ($form.children().length > 0) {
+        $form.append("<div>AND</div>");
+    }
+    let $newRow = $andClause.clone();
+    if (attribute) {
+        $(".keyFields", $newRow).val(attribute);
+    }
+    if (operator) {
+        $(".condition", $newRow).val(operator);
+    }
+    if (value) {
+        $(".valueFields", $newRow).val(value);
+    }
+    $form.append($newRow);
+    return $newRow;
+}
+
+function addOr($and, attribute, operator, value) {
+    let $row = $(".form-row", $and).last();
+    let $newRow = $row.clone();
+    if (attribute) {
+        $(".keyFields", $newRow).val(attribute);
+    }
+    if (operator) {
+        $(".condition", $newRow).val(operator);
+    }
+    if (value) {
+        $(".valueFields", $newRow).val(value);
+    }
+    $row.after($newRow);
+}
+
+function load_query() {
+    // load JSON from textarea and build form...
+    let text = $("#queryJson").val();
+    let jsonData = {};
+    try {
+        jsonData = JSON.parse(text);
+    } catch (error) {
+        alert("Failed to parse JSON");
+        return;
+    }
+    let query_details = jsonData.query_details;
+    if (!query_details) {
+        alert("No 'query_details' in JSON");
+        return;
+    }
+    let and_filters = query_details.and_filters;
+    let or_filters = query_details.or_filters;
+    if (!(and_filters || or_filters)) {
+        alert("No 'and_filters' or 'or_filters' in 'query_details'");
+        return;
+    }
+
+    // Start by clearing form...
+    $("#search_form").empty();
+
+    // handle ANDs...
+    and_filters.forEach(filter => {
+        let { name, operator, value } = filter;
+        addAnd(name, operator, value);
+    });
+
+    // handle ORs...
+    or_filters.forEach(or_filter => {
+        let $and;
+        or_filter.forEach(filter => {
+            let { name, operator, value } = filter;
+            if (!$and) {
+                $and = addAnd(name, operator, value);
+            } else {
+                addOr($and, name, operator, value);
+            }
+        });
+    });
+}
 

--- a/omero_search_client/searchengineclientstatic/js/resource_handeler_new_gui.js
+++ b/omero_search_client/searchengineclientstatic/js/resource_handeler_new_gui.js
@@ -482,57 +482,31 @@ function get_current_query(include_addition_information,displaymessage=true)
     and_conditions=[];
     or_conditions=[];
     //get and condition1
-    queryandnodes=document.getElementById("conanew").childNodes;
-    for ( i in queryandnodes)
-        {
-             if (queryandnodes[i].nodeName=="DIV"  && queryandnodes[i].id.includes("template"))
-            {
-            ext=queryandnodes[i].id.split("_");
-            if (ext.length==1)
-                    ext='';
-            else
-                ext="_"+ext[1];
-            query_dict={};
-            and_conditions.push(query_dict);
-            attribute=document.getElementById("keyFields"+ext).value;
-            condition=document.getElementById("condtion"+ext).value;
-            value=document.getElementById("valueFields"+ext).value;
-            query_dict["name"]=attribute;
-            query_dict["value"]=value;
-            query_dict["operator"]=condition;
-            query_dict["resource"]=get_resource(attribute);
+
+    queryandnodes = document.querySelectorAll('#and_condition .and_clause');
+    console.log(queryandnodes.length);
+    for (let i=0; i<queryandnodes.length; i++) {
+
+        query_dict={};
+
+        let node = queryandnodes[i];
+        // handle each OR...
+        let ors = node.querySelectorAll(".form-row");
+        
+        let or_dicts = [...ors].map(orNode => {
+            return {
+                "name": orNode.querySelector(".keyFields").value,
+                "value": orNode.querySelector(".valueFields").value,
+                "operator": orNode.querySelector(".condition").value,
             }
-            }
-       queryornodes=or_parent.parentNode.childNodes;
-       for ( i in queryornodes)
-            {
-        if (queryornodes[i].nodeName=="DIV"  && queryornodes[i].id.includes("conanewor"))
-            {
-                panel_cond=[];
-        for (j in queryornodes[i].childNodes)
-            {
-        if (queryornodes[i].childNodes[j].nodeName=="DIV"  && queryornodes[i].childNodes[j].id.includes("template") && !queryornodes[i].childNodes[j].id.includes("ortemplate"))
-            {
-            or_conditions.push(panel_cond);
-            console.log("or condition is found "+queryornodes[i].childNodes[j].id);
-            ext_=queryornodes[i].childNodes[j].id.split("_");
-        if (ext_.length==1)
-            ext_='';
-        else
-            ext_="_"+ext_[1];
-       query_dict={};
-       panel_cond.push(query_dict);
-       attribute=document.getElementById("keyFields"+ext_).value;
-       condition=document.getElementById("condtion"+ext_).value;
-       value=document.getElementById("valueFields"+ext_).value;
-       query_dict["name"]=attribute;
-       query_dict["value"]=value;
-       query_dict["operator"]=condition;
-       query_dict["resource"]=get_resource(attribute);
-       }
-                }
-                        }
-                                }
+        });
+        if (or_dicts.length > 1) {
+            or_conditions.push(or_dicts);
+        } else {
+            and_conditions.push(or_dicts[0]);
+        }
+    }
+
     query_details = {}
      var query = {
         "resource": "image",
@@ -986,7 +960,7 @@ let file = document.querySelector("#load_file").files[0];
 
 $(function(){
 
-    function onlyShowOneX() {
+    function hideRemoveIfOnlyOneLeft() {
         let $btns = $("button.remove");
         if ($btns.length == 1) {
             $btns.css('visibility', 'hidden');
@@ -995,12 +969,24 @@ $(function(){
         }
     }
 
+    function getQueryFromForm() {
+
+    }
+
+    // update JSON query
+    function updateForm() {
+        hideRemoveIfOnlyOneLeft();
+
+        query = get_current_query()
+        $("#queryJson").val(JSON.stringify(query, undefined, 4));
+    }
+
     // OR buttons
     $("#and_condition").on("click", ".addOR", function (event) {
         let $clause = $(this).parent();
         let $row = $(".form-row", $clause).last();
         $row.after($row.clone());
-        onlyShowOneX();
+        updateForm();
     });
 
     // X buttons
@@ -1018,10 +1004,10 @@ $(function(){
             $and.remove();
             $clause.remove();
         }
-        onlyShowOneX();
+        updateForm();
     });
 
-    // clone empty form row
+    // clone empty form row before any changes
     let $andClause = $("#and_condition .and_clause").clone();
 
     // AND button
@@ -1030,7 +1016,10 @@ $(function(){
         let $clause = $(".and_clause", $form).last();
         $clause.after($andClause.clone());
         $clause.after("<div>AND</div>");
-        onlyShowOneX();
+        updateForm();
     })
+
+    // initial update
+    updateForm()
 });
 

--- a/omero_search_client/searchengineclientstatic/js/resource_handeler_new_gui.js
+++ b/omero_search_client/searchengineclientstatic/js/resource_handeler_new_gui.js
@@ -960,6 +960,7 @@ let file = document.querySelector("#load_file").files[0];
 
 $(function(){
 
+    // Hide the X button if there's only 1 in the form
     function hideRemoveIfOnlyOneLeft() {
         let $btns = $("button.remove");
         if ($btns.length == 1) {
@@ -967,10 +968,6 @@ $(function(){
         } else {
             $btns.css('visibility', 'visible');
         }
-    }
-
-    function getQueryFromForm() {
-
     }
 
     // update JSON query
@@ -1017,9 +1014,13 @@ $(function(){
         $clause.after($andClause.clone());
         $clause.after("<div>AND</div>");
         updateForm();
-    })
+    });
 
-    // initial update
+    // handle any input/select changes to update textarea
+    $("#and_condition").on("change", "select", updateForm);
+    $("#and_condition").on("keyup", "input", updateForm);
+
+    // initial update of JSON textarea
     updateForm()
 });
 

--- a/omero_search_client/templates/main_page_new_gui.html
+++ b/omero_search_client/templates/main_page_new_gui.html
@@ -44,22 +44,20 @@
                         <select id="keyFields" class="form-control keyFields">
                         </select>
                      </div>
-                     <div class="form-group col-md-3">
+                     <div class="form-group col-md-2">
                         <label for="condtion">Operator</label>
                         <select id="condtion" class="form-control condition">
                         </select>
                      </div>
-
                      <div class="form-group col-md-4" style="position: relative">
-                        <button class="btn btn-sm btn-outline-danger remove">X</button>
                         <label for="valueFields">Value</label>
                         <input type="text" class="form-control valueFields" id="valueFields" onfocus="setAutoCompleteValues()">
                      </div>
+                     <div class="form-group col-md-1 or"><button class="btn btn-sm btn-outline-danger remove">X</button></div>
                   </div>
-                  <button class="btn btn-success addOR" type="button" data-toggle="tooltip" data-placement="top"
-                     title="Add OR condition to the group">
-                     OR
-                  </button>
+                  <a class="addOR" href="#" title="Add OR condition to the group">
+                     add 'OR' rule...
+                  </a>
                </div>
 
                <button id="addAND" type="button" class="btn btn-success" data-toggle="tooltip" data-placement="top"

--- a/omero_search_client/templates/main_page_new_gui.html
+++ b/omero_search_client/templates/main_page_new_gui.html
@@ -28,14 +28,19 @@
 <div id="query">
    <div  id="queryParent">
       <div id="resources" style="display: none"  >
-         <div style="float: right" class="col-md-5">
+         <div style="float: right" class="col-md-6">
+            <button type="button" class="btn btn-info" data-toggle="tooltip" data-placement="top"
+               title="load the query from user storage" onclick="load_query()">
+               Load
+            </button>
+            <br/>
             <textarea id="queryJson">JSON</textarea>
          </div>
 
          <div id="conanew" class="col-md-6">
             <div id="template">
             <br>
-            <form id="and_condition">
+            <form id="search_form">
                <div class="and_clause">
                   <div class="form-row">
                      <div class="form-group col-md-1 or">OR</div>
@@ -59,12 +64,10 @@
                      add 'OR'...
                   </a>
                </div>
-
-               <button id="addAND" type="button" class="btn btn-success" data-toggle="tooltip" data-placement="top"
-                  title="Add group">
-                  add AND
-               </button>
             </form>
+            <button id="addAND" type="button" class="btn btn-success" data-toggle="tooltip" data-placement="top" title="Add group">
+               add AND
+            </button>
          </div>
 
          </div>
@@ -96,12 +99,7 @@
       <button type="button" id="submit_" class="btn btn-primary" data-toggle="tooltip" data-placement="top" title="Submit the query to the server" onclick="submitQuery()">
       Submit
       </button>
-      <button type="button" id="save_query" class="btn btn-info" data-toggle="tooltip" data-placement="top" title="Save the query to the user local storage" onclick="save_query()">
-      Save
-      </button>
-      <button type="button" id="load_query" class="btn btn-info" data-toggle="tooltip" data-placement="top" title="load the query from user storage" onclick="load_query()">
-      Load
-      </button>
+
       <button type="button" id="new_query" class="btn btn-danger" data-toggle="tooltip" data-placement="top" title="Discard all the condition anstart new query" onclick="new_query()">
       New
       </button>

--- a/omero_search_client/templates/main_page_new_gui.html
+++ b/omero_search_client/templates/main_page_new_gui.html
@@ -56,13 +56,13 @@
                      <div class="form-group col-md-1 or"><button class="btn btn-sm btn-outline-danger remove">X</button></div>
                   </div>
                   <a class="addOR" href="#" title="Add OR condition to the group">
-                     add 'OR' rule...
+                     add 'OR'...
                   </a>
                </div>
 
                <button id="addAND" type="button" class="btn btn-success" data-toggle="tooltip" data-placement="top"
                   title="Add group">
-                  AND
+                  add AND
                </button>
             </form>
          </div>

--- a/omero_search_client/templates/main_page_new_gui.html
+++ b/omero_search_client/templates/main_page_new_gui.html
@@ -28,6 +28,10 @@
 <div id="query">
    <div  id="queryParent">
       <div id="resources" style="display: none"  >
+         <div style="float: right" class="col-md-5">
+            <textarea id="queryJson">JSON</textarea>
+         </div>
+
          <div id="conanew" class="col-md-6">
             <div id="template">
             <br>
@@ -37,19 +41,19 @@
                      <div class="form-group col-md-1 or">OR</div>
                      <div class="form-group col-md-4">
                         <label for="keyFields">Attribute</label>
-                        <select id="keyFields" class="form-control">
+                        <select id="keyFields" class="form-control keyFields">
                         </select>
                      </div>
                      <div class="form-group col-md-3">
                         <label for="condtion">Operator</label>
-                        <select id="condtion" class="form-control">
+                        <select id="condtion" class="form-control condition">
                         </select>
                      </div>
 
                      <div class="form-group col-md-4" style="position: relative">
                         <button class="btn btn-sm btn-outline-danger remove">X</button>
                         <label for="valueFields">Value</label>
-                        <input type="text" class="form-control" id="valueFields" onfocus="setAutoCompleteValues()">
+                        <input type="text" class="form-control valueFields" id="valueFields" onfocus="setAutoCompleteValues()">
                      </div>
                   </div>
                   <button class="btn btn-success addOR" type="button" data-toggle="tooltip" data-placement="top"

--- a/omero_search_client/templates/main_page_new_gui.html
+++ b/omero_search_client/templates/main_page_new_gui.html
@@ -28,33 +28,41 @@
 <div id="query">
    <div  id="queryParent">
       <div id="resources" style="display: none"  >
-         <div id="conanew" class="col-md-5">
+         <div id="conanew" class="col-md-6">
             <div id="template">
             <br>
             <form id="and_condition">
+               <div class="and_clause">
+                  <div class="form-row">
+                     <div class="form-group col-md-1 or">OR</div>
+                     <div class="form-group col-md-4">
+                        <label for="keyFields">Attribute</label>
+                        <select id="keyFields" class="form-control">
+                        </select>
+                     </div>
+                     <div class="form-group col-md-3">
+                        <label for="condtion">Operator</label>
+                        <select id="condtion" class="form-control">
+                        </select>
+                     </div>
 
-               <div class="form-row">
-                  <div class="form-group col-md-4">
-                     <label for="keyFields">Attribute</label>
-                     <select id="keyFields" class="form-control">
-                     </select>
+                     <div class="form-group col-md-4" style="position: relative">
+                        <button class="btn btn-sm btn-outline-danger remove">X</button>
+                        <label for="valueFields">Value</label>
+                        <input type="text" class="form-control" id="valueFields" onfocus="setAutoCompleteValues()">
+                     </div>
                   </div>
-                  <div class="form-group col-md-3">
-                     <label for="condtion">Operator</label>
-                     <select id="condtion" class="form-control">
-                     </select>
-                  </div>
-
-                  <div class="form-group col-md-5">
-                     <label for="valueFields">Value</label>
-                     <input type="text" class="form-control" id="valueFields" onfocus="setAutoCompleteValues()">
-                  </div>
-
+                  <button class="btn btn-success addOR" type="button" data-toggle="tooltip" data-placement="top"
+                     title="Add OR condition to the group">
+                     OR
+                  </button>
                </div>
+
+               <button id="addAND" type="button" class="btn btn-success" data-toggle="tooltip" data-placement="top"
+                  title="Add group">
+                  AND
+               </button>
             </form>
-                <button type="button" id="insidebutton" data-toggle="tooltip" data-placement="top" title="Add condition to the 'And Group' to build the query" onclick="addAndConditionFunction('+ Or')">
-            and
-      </button>
          </div>
 
          </div>
@@ -66,10 +74,6 @@
          </div>
                   </div>
       </div>
-
-      <button type="button" class="btn btn-success" data-toggle="tooltip" data-placement="top" title="Add condition to the 'Or Group'" onclick="addOrConditionFunction('+ Or')">
-      + Or
-      </button>
    </div>
    <br>
    <div id ="conditions">

--- a/omero_search_client/templates/main_page_new_gui.html
+++ b/omero_search_client/templates/main_page_new_gui.html
@@ -1,0 +1,170 @@
+{% extends "base.html" %}
+{% import "bootstrap/wtf.html" as wtf %}
+{% block title %}Client for Omero search engine - Index{% endblock %}
+{% block app_content %}+
+<section class="container py-4" style="float : left;">
+    <div class="row">
+        <div class="col-md-12">
+            <!--h2>Idr options</h2-->
+            <ul id="tabs" class="nav nav-tabs">
+                <li class="nav-item"><a href="" data-target="#home1" data-toggle="tab" class="nav-link small text-uppercase">Home</a></li>
+                <li class="nav-item"><a href="" data-target="#querybuilder" data-toggle="tab" class="nav-link small text-uppercase active">Query Builder</a></li>
+                <li class="nav-item"><a href="" data-target="#templates" data-toggle="tab" class="nav-link small text-uppercase">Templates</a></li>
+            </ul>
+            <br>
+            <div id="tabsContent" class="tab-content">
+                <div id="home1" class="tab-pane fade">
+
+                </div>
+                <div id="querybuilder" class="tab-pane fade active show">
+                    <div class="row pb-2">
+
+
+<input type="file" name="load_file" id="load_file" style="display: none" />
+<div class="page-header">
+   <!--h4>Query Builder Form<sup>*</sup></h4-->
+</div>
+<br>
+<div id="query">
+   <div  id="queryParent">
+      <div id="resources" style="display: none"  >
+         <div id="conanew" class="col-md-5">
+            <div id="template">
+            <br>
+            <form id="and_condition">
+
+               <div class="form-row">
+                  <div class="form-group col-md-4">
+                     <label for="keyFields">Attribute</label>
+                     <select id="keyFields" class="form-control">
+                     </select>
+                  </div>
+                  <div class="form-group col-md-3">
+                     <label for="condtion">Operator</label>
+                     <select id="condtion" class="form-control">
+                     </select>
+                  </div>
+
+                  <div class="form-group col-md-5">
+                     <label for="valueFields">Value</label>
+                     <input type="text" class="form-control" id="valueFields" onfocus="setAutoCompleteValues()">
+                  </div>
+
+               </div>
+            </form>
+                <button type="button" id="insidebutton" data-toggle="tooltip" data-placement="top" title="Add condition to the 'And Group' to build the query" onclick="addAndConditionFunction('+ Or')">
+            and
+      </button>
+         </div>
+
+         </div>
+         <br>
+                  <div id="conaneworpar" >
+         <div id="conanewor" class="col-md-5">
+            <div id="ortemplate" >
+      </div>
+         </div>
+                  </div>
+      </div>
+
+      <button type="button" class="btn btn-success" data-toggle="tooltip" data-placement="top" title="Add condition to the 'Or Group'" onclick="addOrConditionFunction('+ Or')">
+      + Or
+      </button>
+   </div>
+   <br>
+   <div id ="conditions">
+      <div class="col-md-5">
+         <div class="float-right">
+            <input class="form-check-input" type="checkbox" value="" id="case_sensitive" >
+            <label class="form-check-label" for="case_sensitive">
+            Case sensitive
+            </label>
+         </div>
+
+
+
+      </div>
+      <br>
+   </div>
+   <div id ="query_buttons">
+      <button type="button" id="submit_" class="btn btn-primary" data-toggle="tooltip" data-placement="top" title="Submit the query to the server" onclick="submitQuery()">
+      Submit
+      </button>
+      <button type="button" id="save_query" class="btn btn-info" data-toggle="tooltip" data-placement="top" title="Save the query to the user local storage" onclick="save_query()">
+      Save
+      </button>
+      <button type="button" id="load_query" class="btn btn-info" data-toggle="tooltip" data-placement="top" title="load the query from user storage" onclick="load_query()">
+      Load
+      </button>
+      <button type="button" id="new_query" class="btn btn-danger" data-toggle="tooltip" data-placement="top" title="Discard all the condition anstart new query" onclick="new_query()">
+      New
+      </button>
+   </div>
+   <br>
+   <br>
+   <div id="results" class="col-md-4" style="display: none"  >
+      <h4>Results</h4>
+      <br>
+      <label id="no_images"></label>
+      <label id="query_id"></label>
+      <br>
+   </div>
+   <th><button id="reset_results_table_filter"  onclick="resetResultsTabelFilters()" type="button"  style="display: none" >Remove Filter/s</button></th>
+    <th><button id="display_dide_columns"  onclick="#" type="button"  style="display: none" >Display/Hide Columns</button></th>
+
+
+   <div id="myGrid_2" style="height: 600px;width:1200px;" class="ag-theme-alpine"></div>
+   <br>
+   <div id="load_results_buttons", style="display: none", class="col-md-7" >
+   <table id="loads_results_table" class="table table-striped">
+      <thead>
+         <tr>
+            <th><button  class="btn btn-primary" id="loadMoreResults"  onclick="loadMoreResultsFunction()" type="button">Load More Results</button></th>
+         </tr>
+         <tr>
+            <th><button id="loadRemainingResults"  onclick="loadRemainingResultsFunction()" type="button" style="display: none">Load All the Results</button></th>
+         </tr>
+      </thead>
+   </table>
+</div>
+<br>
+<button id="exportResults" class="btn btn-primary"  style="display: none"  onclick="exportToCSV()" type="button">Export Results (CSV)</button>
+<br>
+</div>
+<script src={{url_for('static',filename='/js/resource_handeler_new_gui.js')}}></script>
+<script>
+   var resources_data = {{ resources_data|tojson }};
+   var operator_choices= {{ operator_choices|tojson }};
+   var query_id= {{ task_id|tojson }};
+   var mode= {{ mode|tojson }}
+   var submitqueryurl = "{{ url_for('main.submit_query') }}";
+   var queryresultsurl = "{{ url_for('main.queryresults') }}";
+   var  getresourcesvalesforkey = "{{ url_for('main.get_resourcse_key') }}";
+
+   $(document).ajaxStart(function ()
+   {
+   $('body').addClass('wait');
+
+   }).ajaxComplete(function () {
+
+   $('body').removeClass('wait');
+
+   });
+
+
+     $("form").submit(function (e) {
+         e.preventDefault();
+
+     });
+
+
+</script>
+                          </div>
+                </div>
+                <div id="templates" class="tab-pane fade">
+
+            </div>
+        </div>
+    </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
I had a go at implementing what I was trying to describe in the meeting yesterday: adding an OR button to each block and a single AND button to add blocks.
I don't think this is actually functional for searching (I realise I've missed the `resource: 'image'` terms, and I also couldn't work out how to deploy this locally to actually load autocomplete or perform search), but hopefully this is still useful:

<img width="1173" alt="Screenshot 2022-03-03 at 07 31 30" src="https://user-images.githubusercontent.com/900055/156529666-545cd08c-133e-488c-98cd-73c06764c8b9.png">

This shows the same query as in the new GUI:

![Screenshot 2022-03-03 at 17 14 36](https://user-images.githubusercontent.com/900055/156616305-a9e4225d-9615-4de0-82db-0dccb5c49bdf.png)


cc @khaledk2 
