### PR TITLE
Client url config

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -10,6 +10,14 @@ It is also can be used to application script command
 '''
 
 @manager.command
+@manager.option('-u', '--url', help='client url')
+def set_client_url (url=None):
+    if url:
+        update_config_file({"OMERO_SEARCH_ENGINE_CLIENT_URL":url})
+    else:
+        omero_client_app.logger.info("No attribute is provided")
+
+@manager.command
 @manager.option('-u', '--url', help='Search engine url')
 def set_searchengine_url (url=None):
     if url:

--- a/omero_search_client/main/views.py
+++ b/omero_search_client/main/views.py
@@ -39,10 +39,10 @@ def index ():
     may be it is needed to the main template to be more user friendly
     Returns:
     '''
-    resources=get_resources("searchterms")
     # if client_url is set, all other URLs will be based on that URL
     client_url=omero_client_app.config.get("OMERO_SEARCH_ENGINE_CLIENT_URL", "")
-    return render_template('main_page_new_gui.html', client_url=client_url, resources_data=resources, operator_choices=operator_choices,task_id="None", mode="usesearchterms")#container)
+    return render_template('main_page_new_gui.html', client_url=client_url, operator_choices=operator_choices,task_id="None", mode="usesearchterms")#container)
+
 
 @main.route('/<resource>/getresourcenames/',methods=['POST', 'GET'])
 def get_resourcse_names(resource):

--- a/omero_search_client/main/views.py
+++ b/omero_search_client/main/views.py
@@ -25,6 +25,13 @@ def use_advanced_mode():
     resources=get_resources("all")
     return render_template('main_page.html', resources_data=resources,  operator_choices=operator_choices,task_id="None", mode="advanced")#container)
 
+
+@main.route('/searchterms',methods=['POST', 'GET'])
+def searchterms ():
+    resources=get_resources("searchterms")
+    return resources
+
+
 @main.route('/',methods=['POST', 'GET'])
 def index ():
     '''
@@ -33,7 +40,9 @@ def index ():
     Returns:
     '''
     resources=get_resources("searchterms")
-    return render_template('main_page_new_gui.html', resources_data=resources,  operator_choices=operator_choices,task_id="None", mode="usesearchterms")#container)
+    # if client_url is set, all other URLs will be based on that URL
+    client_url=omero_client_app.config.get("OMERO_SEARCH_ENGINE_CLIENT_URL", "")
+    return render_template('main_page_new_gui.html', client_url=client_url, resources_data=resources, operator_choices=operator_choices,task_id="None", mode="usesearchterms")#container)
 
 @main.route('/<resource>/getresourcenames/',methods=['POST', 'GET'])
 def get_resourcse_names(resource):

--- a/omero_search_client/searchengineclientstatic/js/resource_handeler_new_gui.js
+++ b/omero_search_client/searchengineclientstatic/js/resource_handeler_new_gui.js
@@ -713,11 +713,19 @@ $('#jstree_resource_div').bind("dblclick.jstree", function (event) {
 
 });
 }
-$(document).ready(function() {
 
-set_tree_nodes();
+// This is called when the page is ready
+$(document).ready(async function() {
 
-create_tree();
+    // wait while we load resources_data...
+    await fetch(searchtermsurl).then(rsp => rsp.json()).then(data => {
+        resources_data = data;
+    });
+
+    // now we can build tree etc...
+    set_tree_nodes();
+
+    create_tree();
 
 
     let _keys_options = document.getElementById('keyFields');

--- a/omero_search_client/templates/main_page_new_gui.html
+++ b/omero_search_client/templates/main_page_new_gui.html
@@ -190,12 +190,12 @@
    var operator_choices= {{ operator_choices|tojson }};
    var query_id= {{ task_id|tojson }};
    var mode= {{ mode|tojson }}
-   var submitqueryurl = "{{ url_for('main.submit_query') }}";
-   var queryresultsurl = "{{ url_for('main.queryresults') }}";
-   var  getresourcesvalesforkey = "{{ url_for('main.get_resourcse_key') }}";
-   var  searchresourcesvales = "{{ url_for('main.get_resourcse_using_values_only') }}";
-   var  searchresourcesvalesforkey = "{{ url_for('main.get_values_using_values_using_key') }}";
-   var  getresourceskeysusingmode ="{{  url_for('main.get_resourcses_keys') }}";
+   var submitqueryurl = "{{ client_url }}{{ url_for('main.submit_query') }}";
+   var queryresultsurl = "{{ client_url }}{{ url_for('main.queryresults') }}";
+   var  getresourcesvalesforkey = "{{ client_url }}{{ url_for('main.get_resourcse_key') }}";
+   var  searchresourcesvales = "{{ client_url }}{{ url_for('main.get_resourcse_using_values_only') }}";
+   var  searchresourcesvalesforkey = "{{ client_url }}{{ url_for('main.get_values_using_values_using_key') }}";
+   var  getresourceskeysusingmode ="{{ client_url }}{{  url_for('main.get_resourcses_keys') }}";
 
    $(document).ajaxStart(function ()
    {

--- a/omero_search_client/templates/main_page_new_gui.html
+++ b/omero_search_client/templates/main_page_new_gui.html
@@ -186,10 +186,12 @@
 </div>
 <script src={{url_for('static',filename='/js/resource_handeler_new_gui.js')}}></script>
 <script>
-   var resources_data = {{ resources_data|tojson }};
+   // resources_data loaded via searchtermsurl when page loads
+   var resources_data = {};
    var operator_choices= {{ operator_choices|tojson }};
    var query_id= {{ task_id|tojson }};
    var mode= {{ mode|tojson }}
+   var searchtermsurl = "{{ client_url }}{{ url_for('main.searchterms') }}";
    var submitqueryurl = "{{ client_url }}{{ url_for('main.submit_query') }}";
    var queryresultsurl = "{{ client_url }}{{ url_for('main.queryresults') }}";
    var  getresourcesvalesforkey = "{{ client_url }}{{ url_for('main.get_resourcse_key') }}";

--- a/readme.rst
+++ b/readme.rst
@@ -28,3 +28,9 @@ Also, it is needed to setup app data folder using the following command:
 It is possible to deploy the app and the searchengine using Docker images. For more information, please use the following link:
 https://github.com/ome/omero_search_engine/blob/main/docs/configuration/configuration_installtion.rst
 
+If you would like to use an existing deployment of this `searchengine` for all endpoints (except `/`)
+then you can set the `client URL`:
+
+.. code-block::
+
+     path/to/python manage.py set_client_url -u "http://idr.openmicroscopy.org/searchengine"


### PR DESCRIPTION
This allows a developer to do something like this:

```
path/to/python manage.py set_client_url -u "http://idr.openmicroscopy.org/searchengine"
```

Then all URLs in the template will use this prefix, allowing you to load data from an existing deployment, without needing access to the underlying search engine backend.

The index page now doesn't need to load `resources=get_resources("searchterms")` as this data can also be loaded via AJAX (allowing it to be loaded from an existing deployment).

cc @khaledk2 