### PR TITLE
Enable CORS

### DIFF
--- a/omero_search_client/__init__.py
+++ b/omero_search_client/__init__.py
@@ -49,5 +49,14 @@ def create_app(config_name="development"):
     if config_name!= "testing":
         from omero_search_client.app_data import check_copy_data_file
         check_copy_data_file(omero_client_app)
+
+    #add CORS headers
+    @omero_client_app.after_request
+    def after_request(response):
+        header = response.headers
+        header["Access-Control-Allow-Origin"] = "*"
+        header["Access-Control-Allow-Headers"]= "*"
+        return response
+
     return omero_client_app
 

--- a/omero_search_client/__init__.py
+++ b/omero_search_client/__init__.py
@@ -5,7 +5,6 @@ import logging
 import os
 from urllib.parse import urlparse
 from flask import request, url_for as _url_for
-from flask_cors import CORS
 
 from omero_search_client.configuration.config import omero_search_client_app_config, load_configuration_variables_from_file,configLooader
 main_folder=os.path.dirname(os.path.realpath(__file__))
@@ -47,7 +46,6 @@ def create_app(config_name="development"):
     from omero_search_client.main import main as routers_blueprint_main
     omero_client_app.register_blueprint(routers_blueprint_main, url_prefix='/')
     omero_client_app.jinja_env.globals['url_for'] = url_for
-    CORS(omero_client_app)
     if config_name!= "testing":
         from omero_search_client.app_data import check_copy_data_file
         check_copy_data_file(omero_client_app)

--- a/omero_search_client/__init__.py
+++ b/omero_search_client/__init__.py
@@ -5,6 +5,7 @@ import logging
 import os
 from urllib.parse import urlparse
 from flask import request, url_for as _url_for
+from flask_cors import CORS
 
 from omero_search_client.configuration.config import omero_search_client_app_config, load_configuration_variables_from_file,configLooader
 main_folder=os.path.dirname(os.path.realpath(__file__))
@@ -46,6 +47,7 @@ def create_app(config_name="development"):
     from omero_search_client.main import main as routers_blueprint_main
     omero_client_app.register_blueprint(routers_blueprint_main, url_prefix='/')
     omero_client_app.jinja_env.globals['url_for'] = url_for
+    CORS(omero_client_app)
     if config_name!= "testing":
         from omero_search_client.app_data import check_copy_data_file
         check_copy_data_file(omero_client_app)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ Flask-Script==2.0.6
 Flask-Table==0.5.0
 Flask-Testing==0.8.1
 Flask-WTF==0.14.3
-flask-cors==3.0.10
 WTForms==2.3.3
 psycopg2==2.8.6
 python-dateutil==2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ Flask-Script==2.0.6
 Flask-Table==0.5.0
 Flask-Testing==0.8.1
 Flask-WTF==0.14.3
+flask-cors==3.0.10
 WTForms==2.3.3
 psycopg2==2.8.6
 python-dateutil==2.8.1


### PR DESCRIPTION
This uses https://flask-cors.readthedocs.io/en/latest/ to enable CORS across all urls.

This allows apps at other domains to use the search end-points. 